### PR TITLE
docs: add link to the releases page in the other repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,9 @@ What makes sidenoder better than other sideloaders ?
 
 </details>
 
+## Downloading the compiled version
+Compiled binaries can be found in the [vKolerts/sidenoder repository](https://github.com/vKolerts/sidenoder/releases)
+
 ## Running the compiled version
 
 #### Run precompiled release on windows:


### PR DESCRIPTION
Hello, first I would like to thank you for taking up the torch!

This PR just updates the docs to add a link to the other repo with the newer releases, I confess I spent more time than I should've before noticing you were shipping binaries for the newest versions (this repo only contains the [0.6.0 version](https://github.com/vKolerts/quest-sidenoder/releases/tag/v.0.6.0)). 