### PR TITLE
Sort by filename by default

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -1745,7 +1745,13 @@ async function getDir(folder) {
     // console.log({ fileNames });
 
     fileNames.sort((a, b) => {
-      return b.createdAt - a.createdAt;
+      if (a.name > b.name) {
+        return 1;
+      }
+      if (a.name < b.name) {
+        return -1;
+      }
+      return 0;
     });
     // console.log(fileNames)
 


### PR DESCRIPTION
It's frustrating that the file list is sorted by date by default... this patch sorts by filename instead, which I believe most people would prefer.