### PR TITLE
Allow `GameList` and `.meta` in mount root

### DIFF
--- a/main.js
+++ b/main.js
@@ -177,7 +177,7 @@ ipcMain.on('filedrop', async (event, path) => {
 
 
 ipcMain.on('reset_cache', async (event, arg) => {
-  tools.resetCache(arg);
+  await tools.resetCache(arg);
 });
 
 ipcMain.on('get_dir', async (event, arg) => {


### PR DESCRIPTION
It's handy to be able to have the `.meta` folder in root instead of in `Quest Games`.